### PR TITLE
対象OSをwindowsに変更した。 #6

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
現状、tui-rsのバックエンドにcrosstermを使用しており、これはlinux環境に対応していないため。